### PR TITLE
Git grepper

### DIFF
--- a/vim/plugin/git-grepper.vim
+++ b/vim/plugin/git-grepper.vim
@@ -1,6 +1,6 @@
 " Movement operators
-nmap <silent> <leader>gg :set opfunc=GitGrep<cr>g@
-vmap <silent> <leader>gg :<c-u>call GitGrep(visualmode(), 1)<cr>
+nmap <silent> <leader>gg :set opfunc=GitGrepOperator<cr>g@
+vmap <silent> <leader>gg :<c-u>call GitGrepOperator(visualmode(), 1)<cr>
 
 " Command
 command! -nargs=+ GitGrep call GitGrepCommand(Sanitize('<args>'))
@@ -34,7 +34,7 @@ function! GetBackToOriginalFile()
     execute "edit " . g:GREP_ORIGINAL_FILE
 endfunction
 
-function! GitGrep(type, ...)
+function! GitGrepOperator(type, ...)
     " get text
     if a:type ==# 'char'
         execute "normal! `[v`]y"
@@ -54,7 +54,7 @@ function! GitGrep(grep_string)
     " the -n is necessary for vim to correctly interpret matches
     let &grepprg = "git grep -n $*"
     let cmd = "silent grep! " . shellescape(a:grep_string)
-    echom cmd
+    execute cmd
     " restore display
     execute "normal! \<c-l>"
     " restore grep to its original value

--- a/vim/plugin/git-grepper.vim
+++ b/vim/plugin/git-grepper.vim
@@ -1,5 +1,38 @@
+" Movement operators
 nmap <silent> <leader>gg :set opfunc=GitGrep<cr>g@
 vmap <silent> <leader>gg :<c-u>call GitGrep(visualmode(), 1)<cr>
+
+" Command
+command! -nargs=+ GitGrep call GitGrepCommand(Sanitize('<args>'))
+" Sets a binding to come back to the original file after moving around
+" in the quickfix list. This will stay set to the same file until the
+" next grep search. Default is NOOP.
+nnoremap <silent> <leader>o :call GetBackToOriginalFile()<cr>
+
+function! Sanitize(args)
+    " Takes in the command arguments and returns a list
+    " Also takes care of additional spaces (leading trailing are auto removed) spaces
+    let args_string = substitute(a:args, '\v\ {2,}', ' ', 'g')
+    return split(args_string, ' ')
+endfunction
+
+function! GitGrepCommand(args)
+    " TODO for now this will bug if not simply inserting a keyword
+    let grep_string = ""
+    for arg in a:args
+        let grep_string = grep_string . arg
+    endfor
+    call GitGrep(grep_string)
+endfunction
+
+function! GetBackToOriginalFile()
+    if !exists("g:GREP_ORIGINAL_FILE")
+        " Default to current file
+        let g:GREP_ORIGINAL_FILE = @%
+    endif
+    echom g:GREP_ORIGINAL_FILE
+    execute "edit " . g:GREP_ORIGINAL_FILE
+endfunction
 
 function! GitGrep(type, ...)
     " get text
@@ -10,11 +43,18 @@ function! GitGrep(type, ...)
     else
         return
     endif
-    " not forgetting the shell escape
+    call GitGrep(@@)
+endfunction
+
+function! GitGrep(grep_string)
+    if a:grep_string ==# ""
+        return
+    endif
     let original_grep = &grepprg
     " the -n is necessary for vim to correctly interpret matches
     let &grepprg = "git grep -n $*"
-    execute "silent grep! '" . shellescape(@@) . "'"
+    let cmd = "silent grep! " . shellescape(a:grep_string)
+    echom cmd
     " restore display
     execute "normal! \<c-l>"
     " restore grep to its original value

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -76,12 +76,6 @@ nnoremap <leader>j <c-w>j
 nnoremap <leader>l <c-w>l
 " duplicate line
 nnoremap <leader>dl Vyp
-" " search and replace last yank in selection
-" nnoremap <leader>sr :%s/<c-r>0//g<left><left>
-" nnoremap <leader>src :%s/<c-r>0//gc<left><left><left>
-" " or in all file
-" vnoremap <leader>sr :s/<c-r>0//g<left><left>
-" vnoremap <leader>src :s/<c-r>0//gc<left><left><left>
 " use \v (very magic) mode on searches
 nnoremap / /\v
 nnoremap ? ?\v
@@ -91,6 +85,7 @@ nnoremap <leader>cs :match none<cr>:nohlsearch<cr>
 nnoremap <leader>vsP :execute "rightbelow vsplit" bufname("#")<cr>
 " open previous buffer in current window
 nnoremap <leader>P :execute "edit " . bufname("#")<cr> " go to previous and next quickfix entry
+" navigate in the quickfix list
 nnoremap <leader>n :cnext<cr>
 nnoremap <leader>p :cprevious<cr>
 " }}}


### PR DESCRIPTION
## What?
* add a first version of the `:GitGrep` command
    * for now, accepts only a single argument, without spaces
    * it will perform search on whole project
* added a `go back to original file` function
    * use `<leader>o` to go back to the original file, where `original file` is the buffer that was current when the operator was used. Also works for the command version